### PR TITLE
Avoid spurious /EN signal at reset

### DIFF
--- a/BCN3D-Boot/stk500boot.c
+++ b/BCN3D-Boot/stk500boot.c
@@ -532,7 +532,7 @@ void (*app_start)(void) = 0x0000;
 void init_ports(void){
 	
 	PORTJ= 0b00010000;
-	DDRJ = 0x00111000;	//// X0 step PJ3 "0" , IEN PJ4 "1", DIR PJ5 "0"
+	DDRJ = 0b00111000;	//// X0 step PJ3 "0" , IEN PJ4 "1", DIR PJ5 "0"
 	
 	PORTE= 0b00010000;
 	DDRE = 0b00111000;	//// X1 step  PE3, IEN PE4 "1", DIR PE5 "0"
@@ -547,7 +547,7 @@ void init_ports(void){
 	DDRF = 0b00001110;	//// E1 step  PF3, IEN PF2 "1", DIR PF1 "0"
 	
 	PORTB= 0b00000000;
-	DDRB = 0x00010000;	//// Relay "0"
+	DDRB = 0b00010000;	//// Relay "0"
 }
 //*****************************************************************************
 int main(void)

--- a/BCN3D-Boot/stk500boot.c
+++ b/BCN3D-Boot/stk500boot.c
@@ -530,23 +530,24 @@ uint32_t count = 0;
 void (*app_start)(void) = 0x0000;
 
 void init_ports(void){
-	DDRJ = 0x00111000;	//// X0 step PJ3 "0" , IEN PJ4 "1", DIR PJ5 "0"
+	
 	PORTJ= 0b00010000;
+	DDRJ = 0x00111000;	//// X0 step PJ3 "0" , IEN PJ4 "1", DIR PJ5 "0"
 	
-	DDRE = 0b00111000;	//// X1 step  PE3, IEN PE4 "1", DIR PE5 "0"
 	PORTE= 0b00010000;
+	DDRE = 0b00111000;	//// X1 step  PE3, IEN PE4 "1", DIR PE5 "0"
 	
-	DDRC = 0b11100000;	//// Y step  PC7, IEN PC6 "1", DIR PC5 "0"
 	PORTC= 0b01000000;
+	DDRC = 0b11100000;	//// Y step  PC7, IEN PC6 "1", DIR PC5 "0"
 	
-	DDRA = 0b11101110;	//// Z step  PA3, IEN PA2 "1", DIR PA1 "0"  & E0 step PA7, IEN PA6 "1", DIR PA5 "0"
 	PORTA= 0b01000100;
+	DDRA = 0b11101110;	//// Z step  PA3, IEN PA2 "1", DIR PA1 "0"  & E0 step PA7, IEN PA6 "1", DIR PA5 "0"
 	
-	DDRF = 0b00001110;	//// E1 step  PF3, IEN PF2 "1", DIR PF1 "0"
 	PORTF= 0b00000100;
+	DDRF = 0b00001110;	//// E1 step  PF3, IEN PF2 "1", DIR PF1 "0"
 	
-	DDRB = 0x00010000;	//// Relay "0"
 	PORTB= 0b00000000;
+	DDRB = 0x00010000;	//// Relay "0"
 }
 //*****************************************************************************
 int main(void)


### PR DESCRIPTION
Problem: current bootloader code generate a spurious /EN signal on all stepper drivers.
Reason: current bootloader code does not follow best practices for gpio initialization.

Original code logic:
0. All pins are INPUT without pullup after reset (standard AVR behavior)
1. Set DDRx -> pins goes from INPUT without pullup to OUTPUT with LOW state (/EN is enabled)
2. Set PORTx -> pins goes from LOW to HIGH state (/EN is disabled)
3. Result: motors make a loud "bang" at reset because of the spurious /EN signal.

New code logic:
0. All pins are INPUT without pullup after reset (standard AVR behavior)
1. Set PORTx -> pins goes from INPUT **without** pullup to INPUT **with** pullup (= weak "HIGH" state)
2. Set DDRx -> pins goes from INPUT with pullup to OUTPUT with HIGH state
3. Result: no more spurious /EN signal.

Side note : 
The stepper drivers boards or motherboard should include external pullup resistors to avoid floating states.
Relying on internal pullup resistor and software for this is an electrical design flaw. Period.